### PR TITLE
Add devcontainer, linters and formatters

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,92 @@
+//========================================================================
+// Copyright Universidade Federal do Espirito Santo (Ufes)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// This program is released under license GNU GPL v3+ license.
+//
+//========================================================================
+
+// For format details, see https://aka.ms/devcontainer.json. For config
+// options, see the README at:
+// https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	// A name for the dev container displayed in the UI.
+	"name": "dev-relax",
+
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20",
+	// Or use a Dockerfile or Docker Compose file. More info:
+	// https://containers.dev/guide/dockerfile
+	// "build": {
+	//   // Sets the run context to the same level of the .devcontainer folder.
+	//   "context": ".",
+	//   // Update the 'dockerFile' property if you aren't using the standard
+	//   // 'Dockerfile' filename.
+	//   "dockerfile": "Dockerfile"
+	// },
+	// "dockerComposeFile": "docker-compose.yml",
+	// "service": "devcontainer",
+
+	// An array of Docker CLI arguments that should be used when running the
+	// container.
+	"runArgs": ["--name=dev-relax", "--rm", "-p", "8088:8088", "--network=host"],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "yarn install && export NODE_OPTIONS=--openssl-legacy-provider && yarn serve",
+
+	// Indicates whether devcontainer.json supporting tools should stop the
+	// containers when the related tool window is closed / shut down.
+	"shutdownAction": "stopContainer",
+	// "shutdownAction": "stopCompose",
+
+	// Sets the default path that devcontainer.json supporting services / tools
+	// should open when connecting to the container. Defaults to the automatic
+	// source code mount location.
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container.
+	// More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container
+	// available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+				"esbenp.prettier-vscode",
+				"foxundermoon.shell-format",
+				"ms-azuretools.vscode-docker",
+				"davidanson.vscode-markdownlint",
+				"fnando.linter",
+				"streetsidesoftware.code-spell-checker",
+				"sirtobi.pegjs-language"
+			]
+		}
+	},
+
+	// Comment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "node",
+	"features": {
+		"ghcr.io/akhildevelops/devcontainer-features/apt:0": {},
+		"ghcr.io/devcontainers/features/git:1": {
+			"ppa": true,
+			"version": "os-provided"
+		}
+	}
+}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,59 @@
+/*
+ * An example .markdownlint-cli2.jsonc file
+ */
+{
+  // Disable some built-in rules
+  // "config": {
+  //   "no-trailing-spaces": false,
+  //   "no-multiple-blanks": false
+  // },
+
+  // Include a custom rule package
+  // "customRules": [
+  //   "markdownlint-rule-titlecase"
+  // ],
+
+  // Fix any fixable errors
+  // "fix": true,
+
+  // Define a custom front matter pattern
+  // "frontMatter": "<head>[^]*<\/head>",
+
+  // Ignore files referenced by .gitignore (only valid at root)
+  // "gitignore": true,
+
+  // Define glob expressions to use (only valid at root)
+  // "globs": [
+  //   "!*bout.md"
+  // ],
+
+  // Define glob expressions to ignore
+  "ignores": [".gitignore", "LICENSE"]
+
+  // Use a plugin to recognize math
+  // "markdownItPlugins": [
+  //   [ "@iktakahiro/markdown-it-katex" ]
+  // ],
+
+  // Additional paths to resolve module locations from
+  // "modulePaths": [
+  //   "./modules"
+  // ],
+
+  // Disable banner message on stdout (only valid at root)
+  // "noBanner": true,
+
+  // Disable inline config comments
+  // "noInlineConfig": true,
+
+  // Disable progress on stdout (only valid at root)
+  // "noProgress": true,
+
+  // Use a specific formatter (only valid at root)
+  // "outputFormatters": [
+  //   [ "markdownlint-cli2-formatter-default" ]
+  // ],
+
+  // Show found files on stdout (only valid at root)
+  // "showFound": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,50 @@
 {
+	"markdownlint.config": {
+		"MD033": false
+	},
+	"shellformat.effectLanguages": ["dotenv", "ignore", "gitignore"],
+	"[dotenv]": {
+		"editor.formatOnSave": true,
+		"editor.defaultFormatter": "foxundermoon.shell-format"
+	},
+	"[gitignore]": {
+		"editor.formatOnSave": true,
+		"editor.defaultFormatter": "foxundermoon.shell-format"
+	},
+	"[ignore]": {
+		"editor.formatOnSave": true,
+		"editor.defaultFormatter": "foxundermoon.shell-format"
+	},
+	"[jsonc]": {
+		"editor.formatOnSave": true,
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"[markdown]": {
+		"editor.formatOnSave": true,
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	},
+	"linter.linters": {
+		"markdownlint": {
+			"capabilities": ["fix-inline"],
+			"command": [
+				"markdownlint",
+				"--json",
+				["$fixAll", "--fix"],
+				["$config", "--config", "$config"],
+				"--stdin"
+			],
+			"configFiles": [
+				".markdownlint.json",
+				".markdownlint.yaml",
+				".markdownlint.yml",
+				".markdownlintrc"
+			],
+			"enabled": true,
+			"languages": ["markdown"],
+			"name": "markdownlint",
+			"url": "https://github.com/DavidAnson/markdownlint"
+		}
+	},
 	"typescript.tsdk": "./node_modules/typescript/lib",
 	"search.exclude": {
 		"**/node_modules": true,


### PR DESCRIPTION
- Requirements: Docker and VS Code;
- No need to install other dependencies (e.g., npm and yarn);
- Dev container includes relevant linters and code formatters;

How to use it:
- Open Visual Studio Code;
- Press `Ctrl`+`Shit`+`P` (or `Cmd`+`Shit`+`P` on OS X);
- Type in "Reopen in Container" and press `Enter`;
- After reopening, the app will be built and will be accessible at http://localhost:8088;
- It still allows using Git seamlessly from within the container.
