### PR TITLE
Fix date with empty string and handle invalid date format during execution

### DIFF
--- a/src/calc2/components/editorBagalg.tsx
+++ b/src/calc2/components/editorBagalg.tsx
@@ -100,6 +100,7 @@ export class EditorBagalg extends React.Component<Props, State> {
 					return {
 						result: (
 							<Result
+								editorRef={this.editorBase!}
 								root={root}
 								numTreeLabelColors={NUM_TREE_LABEL_COLORS}
 								execTime={self.state.execTime == null ? 0 : self.state.execTime}

--- a/src/calc2/components/editorRelalg.tsx
+++ b/src/calc2/components/editorRelalg.tsx
@@ -100,6 +100,7 @@ export class EditorRelalg extends React.Component<Props, State> {
 					return {
 						result: (
 							<Result
+								editorRef={this.editorBase!}
 								root={root}
 								numTreeLabelColors={NUM_TREE_LABEL_COLORS}
 								execTime={self.state.execTime == null ? 0 : self.state.execTime}

--- a/src/calc2/components/editorSql.tsx
+++ b/src/calc2/components/editorSql.tsx
@@ -90,6 +90,7 @@ export class EditorSql extends React.Component<Props> {
 						return {
 							result: (
 								<Result
+									editorRef={this.editorBase!}
 									root={root}
 									numTreeLabelColors={NUM_TREE_LABEL_COLORS}
 									execTime={self.state.execTime == null ? 0 : self.state.execTime}

--- a/src/calc2/components/result.tsx
+++ b/src/calc2/components/result.tsx
@@ -11,12 +11,15 @@ import { Table } from 'db/exec/Table';
 import memoize from 'memoize-one';
 import * as React from 'react';
 import {t} from "calc2/i18n";
+import { EditorBase } from './editorBase';
+import { ExecutionError } from 'db/exec/ExecutionError';
 
 require('./result.scss');
 
 const maxLinesPerPage = 10;
 
 type Props = {
+	editorRef: EditorBase,
 	root: RANode,
 	numTreeLabelColors: number,
 	execTime?: any,
@@ -38,8 +41,7 @@ export class Result extends React.Component<Props, State> {
 				return node.getResult(doEliminateDuplicates);
 			}
 			catch (e) {
-				console.error(e);
-				return null;
+				return e;
 			}
 		},
 	);
@@ -64,11 +66,15 @@ export class Result extends React.Component<Props, State> {
 	}
 
 	render() {
-		const { root, numTreeLabelColors, execTime, doEliminateDuplicates } = this.props;
+		const { editorRef, root, numTreeLabelColors, execTime, doEliminateDuplicates } = this.props;
 		const { activeNode } = this.state;
 
 		const result = this.result(activeNode, doEliminateDuplicates);
-
+		if (result instanceof ExecutionError) {
+			const errorMessage = result.message;
+			editorRef.addExecutionError(errorMessage);
+			return;
+		}
 
 		return (
 			<div className="ra-result clearfix">

--- a/src/db/exec/ValueExpr.ts
+++ b/src/db/exec/ValueExpr.ts
@@ -387,7 +387,7 @@ export class ValueExprGeneric extends ValueExpr {
 
 			case 'date':
 				// Check wether the date format is valid
-				if (this?._args?.[0]?._args?.[0]) {
+				if (this?._args?.[0]?._args?.[0] !== undefined) {
 					this._parseIsoDate(this._args[0]._args[0]);
 				}
 				return this._checkArgsDataType(schemaA, schemaB, ['string']);


### PR DESCRIPTION
This PR:

- Highlights invalid date format while typing if an empty string is used as parameter of the `date` function;

Database [Employee (Franklin University)](http://localhost:8088/relax/calc/local/uibk/local/6)

```sql
pi date('')->d EMPLOYEE
````

Before:
![Screenshot 2024-10-16 at 11 04 32](https://github.com/user-attachments/assets/626da334-9451-4962-95b5-656250dc7386)

After:
![Screenshot 2024-10-16 at 11 03 13](https://github.com/user-attachments/assets/8786b53d-e709-4847-a981-f4b48712a5bd)

- Shows error message if the date check problem happens during execution;

Database [Employee (Franklin University)](http://localhost:8088/relax/calc/local/uibk/local/6)

```sql
pi date(Fname)->d EMPLOYEE
````

Before (after clicking on the `execute query`):
![Screenshot 2024-10-16 at 11 09 46](https://github.com/user-attachments/assets/431251a5-0500-4af7-9802-2fedc502af62)

After:
![Screenshot 2024-10-16 at 11 06 38](https://github.com/user-attachments/assets/a6662219-29f0-460f-bb35-e46c4f57c6ea)

PS: I'd suggest reverting the changes in [src/db/parser/grammar_bags.d.ts](https://github.com/dbis-uibk/relax/pull/217/files#diff-c493d8351d7113e7d677717786196c67c621c98cd42d3209d59e7a9fef13f124) because the problem is not date-related and it will be fixed in https://github.com/dbis-uibk/relax/pull/215
